### PR TITLE
Adding `underscore` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "bignum": "0.6.x",
-    "ipv6": "3.1.x"
+    "ipv6": "3.1.x",
+    "underscore": "^1.6.0"
   },
   "devDependencies": {
     "nodeunit": "0.8.x",


### PR DESCRIPTION
It's only in devDependencies as is, so the module won't work unless
you have underscore globally installed or you go in and do an
`npm install` to trigger downloading underscore, or manually install it
yourself.

Since the main library uses underscore, it should be in dependencies.
