### PR TITLE
upgrade from ipv6 to ip-address since ipv6 is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Supported encoding specifications
 >> For `ipv6`, if `data` is a buffer, it is expected to be the binary representation
 >> of an IPv6 address (16 bytes). It **cannot** be a textual representation. If it is a string,
 >> it can be on any valid IPv6 form (e.g. `::1` or `1080:0:0:0:8:800:200c:417a`,
->> parsing is done using [javascript-ipv6][JavaScriptIPv6]).
+>> parsing is done using [ip-address][IPAddress]).
 >
 > **returns**
 >> A `String` with the encoded data.
@@ -144,4 +144,4 @@ it's slow but it does the job. Now let's poke those processor designers for 128-
 [Base85IPv6]: http://tools.ietf.org/html/rfc1924
 [JSCompare]: http://stackoverflow.com/questions/359494/does-it-matter-which-equals-operator-vs-i-use-in-javascript-comparisons
 [SGML]: https://en.wikipedia.org/wiki/Standard_Generalized_Markup_Language
-[JavaScriptIPv6]: https://github.com/beaugunderson/javascript-ipv6
+[IPAddress]: https://www.npmjs.com/package/ip-address

--- a/lib/base85.js
+++ b/lib/base85.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var alphabets = require('./alphabets');
-var v6 = require('ipv6').v6;
+var Address6 = require('ip-address').Address6;
 var bignum = require('bignum');
 
 var NUM_MAXVALUE = Math.pow(2, 32) - 1;
@@ -56,7 +56,7 @@ function encodeBufferIPv6(buffer)
 
 function encodeStringIPv6(string)
 {
-  var addr = new v6.Address(string);
+  var addr = new Address6(string);
   if (!addr.isValid()) {
     return false;
   }
@@ -77,14 +77,20 @@ function decodeStringIPv6(string)
 
   var dectable = alphabets.ipv6.dec;
   var i = 0;
-  var binary = string.split('').reduceRight(function(memo, el) {
-    var num = bignum(dectable[el.charCodeAt(0)]);
-    var fact = bignum(85).pow(i++);
-    var contrib = num.mul(fact);
-    return memo.add(contrib);
-  }, bignum(0));
 
-  return v6.Address.fromBigInteger(binary).correctForm();
+  /* bignum throws an exception if invalid data is passed */
+  try {
+    var binary = string.split('').reduceRight(function(memo, el) {
+      var num = bignum(dectable[el.charCodeAt(0)]);
+      var fact = bignum(85).pow(i++);
+      var contrib = num.mul(fact);
+      return memo.add(contrib);
+    }, bignum(0));
+
+    return Address6.fromBigInteger(binary).correctForm();
+  } catch(e) {
+    return false;
+  }
 }
 
 function decodeBufferIPv6(buffer)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Base85 (Ascii85) encode and decode functionality",
   "main": "lib/base85.js",
   "scripts": {
-    "test": "./node_modules/.bin/jshint . && ./node_modules/.bin/nodeunit tests"
+    "test": "jshint . && nodeunit tests"
   },
   "dependencies": {
     "bignum": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "bignum": "^0.11.0",
-    "ipv6": "^3.1.0",
+    "ip-address": "^5.0.2",
     "underscore": "^1.6.0"
   },
   "devDependencies": {

--- a/tests/data.js
+++ b/tests/data.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.data = [
   {
     'raw' : new Buffer('Man ', 'ascii'),


### PR DESCRIPTION
I'm the author of the ipv6 and ip-address modules, here's a PR that upgrades from ipv6 (now deprecated) to ip-address. :)

I also fixed an intermittent test bug by throwing an exception if bignum is unable to handle its input. It happened sometimes when I ran the tests via `npm test` but not if I just ran the ipv6 tests via nodeunit. Very weird, but probably better to handle the error case there anyway.

I also [removed the hardcoded paths](https://twitter.com/izs/status/657976995326726144) from the test script.