### PR TITLE
support usage in WebWorkers

### DIFF
--- a/lib/base85.js
+++ b/lib/base85.js
@@ -10,7 +10,7 @@ const SING85 = 85;
 
 const DEFAULT_ENCODING = 'z85';
 
-const LBigInt = typeof window !== 'undefined' ? window.BigInt : global.BigInt;
+const LBigInt = typeof window !== 'undefined' ? window.BigInt : typeof self !== 'undefined' ? self.BigInt : global.BigInt;
 
 /* Characters to allow (and ignore) in an encoded buffer */
 const IGNORE_CHARS = [


### PR DESCRIPTION
The global object is called 'self' in web workers, not window or global. This adds a check for 'self' when getting the BigInt reference.